### PR TITLE
clearing Interval when res.end() is called

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,9 @@
       req.on('close', function() {
         return clearInterval(interval);
       });
+      req.on('end', function() {
+        return clearInterval(interval);
+      });
       if (next != null) {
         return next();
       }


### PR DESCRIPTION
Hi,

When `res.end()` is called, the interval still continues causing a `write after end` error. `close` only handles the case when client terminates the connection. Added `end` to deal with this case.
